### PR TITLE
Implement rate limiting for refreshes triggered by unknown kids

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ welcome though.
 	* A custom background refresh request context timeout can be specified. Defaults to one minute.
 	* A custom background refresh error handling function can be specified. If none is specified, errors go unhandled
 	  silently.
-* JWTs with a previously unseen `kid` can prompt an automatic refresh of the remote JWKs resource.
+* JWTs with a previously unseen `kid` can prompt an automatic refresh of the remote JWKs resource. This behavior can
+    also be rate limited to mitigate denial of service attacks.
 * A custom HTTP client can be used. This is possible by passing
   [`keyfunc.Options`](https://pkg.go.dev/github.com/MicahParks/keyfunc#Options) via a variadic argument to the
   [`keyfunc.Get`](https://pkg.go.dev/github.com/MicahParks/keyfunc#Get) function.

--- a/examples/unknown/main.go
+++ b/examples/unknown/main.go
@@ -17,16 +17,15 @@ func main() {
 	jwksURL := "https://jwks-service.appspot.com/.well-known/jwks.json"
 
 	// Create the keyfunc options. Use an error handler that logs. Refresh the JWKs when a JWT signed by an unknown KID
-	// is found. Timeout the initial JWKs refresh request after 10 seconds. This timeout is also used to create the
-	// initial context.Context for keyfunc.Get.
+	// is found, at a maximum of one unknown KID-triggered refresh per five minutes.
 	refreshUnknownKID := true
-	refreshTimeout := time.Second * 10
+	unknownRefreshInterval := 5 * time.Minute
 	options := keyfunc.Options{
-		RefreshTimeout: &refreshTimeout,
 		RefreshErrorHandler: func(err error) {
 			log.Printf("There was an error with the jwt.KeyFunc\nError: %s", err.Error())
 		},
-		RefreshUnknownKID: &refreshUnknownKID,
+		RefreshUnknownKID:            &refreshUnknownKID,
+		RefreshUnknownKIDMinInterval: &unknownRefreshInterval,
 	}
 
 	// Create the JWKs from the resource at the given URL.

--- a/get.go
+++ b/get.go
@@ -109,8 +109,8 @@ func (j *JWKs) refresh() (err error) {
 	}
 
 	// Lock the JWKs for async safe usage.
-	j.mux.Lock()
-	defer j.mux.Unlock()
+	j.keysMux.Lock()
+	defer j.keysMux.Unlock()
 
 	// Update the keys.
 	j.Keys = updated.Keys

--- a/options.go
+++ b/options.go
@@ -24,10 +24,15 @@ type Options struct {
 	// if RefreshInterval is not nil.
 	RefreshErrorHandler ErrorHandler
 
-	// RefreshUnknownKID indicates that the JWKs should be refreshed via HTTP every time a kid that isn't known is
-	// found. This means that a malicious client could self-sign X JWTs, send them to this service, then cause
-	// potentially high network usage proportional to X.
+	// RefreshUnknownKID indicates that the JWKs should be refreshed via HTTP every time a kid that isn't known is found.
+	// On its own, this behavior allows a malicious client to self-sign X JWTs, send them to this service, then cause
+	// potentially high network usage proportional to X. Set a RefreshUnknownMinTimespan to mitigate this issue.
 	RefreshUnknownKID *bool
+
+	// RefreshUnknownKIDminInterval is the duration that must pass between any two unknown-kid-triggered JWK refreshes.
+	// Setting this to a reasonable value helps prevent malicious clients from launching a denial of service attack by
+	// sending fake or self-signed JWTs.
+	RefreshUnknownKIDMinInterval *time.Duration
 }
 
 // applyOptions applies the given options to the given JWKs.
@@ -46,5 +51,8 @@ func applyOptions(jwks *JWKs, options Options) {
 	}
 	if options.RefreshUnknownKID != nil {
 		jwks.refreshUnknownKID = *options.RefreshUnknownKID
+	}
+	if options.RefreshUnknownKIDMinInterval != nil {
+		jwks.refreshUnknownKIDminInterval = options.RefreshUnknownKIDMinInterval
 	}
 }


### PR DESCRIPTION
Thanks for the amazing library! It's come in quite helpful :)

Regarding this PR: this behavior is recommended by Auth0, for instance: https://community.auth0.com/t/caching-jwks-signing-key/17654/2

I updated the README and examples with this new functionality, but could use a bit of guidance on how to test it effectively. I am also open to feedback on the strucuture/naming/etc. of the code.

