### PR TITLE
Upstream migrated to github.com/golang-jwt/jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
 })
 ```
 
+### Support for [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go)
+This project originally only supported [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go), but since it
+is no longer maintained, it's method was moved
+to [`JWKs.KeyFuncLegacy`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKs.KeyFuncLegacy) if you have not moved to
+[github.com/golang-jwt/jwt](https://github.com/golang-jwt/jwt) yet.
+
 ## Test coverage
 
 Test coverage is currently at `87.4%`.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
 
 ## Test coverage
 
-Test coverage is currently at `88.5%`.
+Test coverage is currently at `87.4%`.
 
 This is with current and expired JWTs, but the hard coded ones are now expired. Using non-expired JWTs would require
 signing JWTs during testing and would allow for additional error checking. But a bit overkill since I've already done

--- a/README.md
+++ b/README.md
@@ -3,17 +3,20 @@
 # keyfunc
 
 Purpose of this package is to provide a
-[`jwt.Keyfunc`](https://pkg.go.dev/github.com/dgrijalva/jwt-go@v3.2.0+incompatible#Keyfunc) for the
-[github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go) package and its popular forks using a JSON Web Key
-Set (JWKs) for parsing and verifying JSON Web Tokens (JWTs).
+[`jwt.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt#Keyfunc) for the
+[github.com/golang-jwt/jwt](https://github.com/golang-jwt/jwt) package and its popular forks using a JSON Web Key Set
+(JWKs) for parsing and verifying JSON Web Tokens (JWTs). This
+was [formally](https://github.com/dgrijalva/jwt-go/issues/462)
+the [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go) package.
 
 It's common for an identity provider, such as [Keycloak](https://www.keycloak.org/)
 or [Amazon Cognito (AWS)](https://aws.amazon.com/cognito/) to expose a JWKs via an HTTPS endpoint. This package has the
 ability to consume that JWKs and produce a
-[`jwt.Keyfunc`](https://pkg.go.dev/github.com/dgrijalva/jwt-go@v3.2.0+incompatible#Keyfunc). It is important that a JWKs
+[`jwt.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt#Keyfunc). It is important that a JWKs
 endpoint is using HTTPS to ensure the keys are from the correct trusted source.
 
 This repository has the following dependencies:
+* [github.com/golang-jwt/jwt](https://github.com/golang-jwt/jwt)
 * [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go)
 * [github.com/form3tech-oss/jwt-go](https://github.com/form3tech-oss/jwt-go)
 
@@ -63,7 +66,7 @@ jwksURL := os.Getenv("JWKS_URL")
 
 // Confirm the environment variable is not empty.
 if jwksURL == "" {
-	log.Fatalln("JWKS_URL environment variable must be populated.")
+log.Fatalln("JWKS_URL environment variable must be populated.")
 }
 ```
 
@@ -73,7 +76,7 @@ Via HTTP:
 // Create the JWKs from the resource at the given URL.
 jwks, err := keyfunc.Get(jwksURL)
 if err != nil {
-	log.Fatalf("Failed to get the JWKs from the given URL.\nError:%s\n", err.Error())
+log.Fatalf("Failed to get the JWKs from the given URL.\nError:%s\n", err.Error())
 }
 ```
 Via JSON:
@@ -84,7 +87,7 @@ var jwksJSON = json.RawMessage(`{"keys":[{"kid":"zXew0UJ1h6Q4CCcd_9wxMzvcp5cEBif
 // Create the JWKs from the resource at the given URL.
 jwks, err := keyfunc.New(jwksJSON)
 if err != nil {
-	log.Fatalf("Failed to create JWKs from JSON.\nError:%s\n", err.Error())
+log.Fatalf("Failed to create JWKs from JSON.\nError:%s\n", err.Error())
 }
 ```
 
@@ -92,13 +95,13 @@ Additional options can be passed to the [`keyfunc.Get`](https://pkg.go.dev/githu
 via variadic arguments. See [`keyfunc.Options`](https://pkg.go.dev/github.com/MicahParks/keyfunc#Options) and the
 additional features mentioned at the bottom of this `README.md`.
 
-### Step 2: Use the [`keyfunc.JWKs`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKs) 's [`JWKs.KeyFunc`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKs.KeyFunc) method as the [`jwt.Keyfunc`](https://pkg.go.dev/github.com/dgrijalva/jwt-go@v3.2.0+incompatible#Keyfunc) when parsing tokens
+### Step 2: Use the [`keyfunc.JWKs`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKs) 's [`JWKs.KeyFunc`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKs.KeyFunc) method as the [`jwt.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt#Keyfunc) when parsing tokens
 
 ```go
 // Parse the JWT.
 token, err := jwt.Parse(jwtB64, jwks.KeyFunc)
 if err != nil {
-	return nil, fmt.Errorf("failed to parse token: %w", err)
+return nil, fmt.Errorf("failed to parse token: %w", err)
 }
 ```
 
@@ -107,8 +110,8 @@ key with the matching `kid` (if present) and return its public key as the correc
 
 ## Fork support
 
-Some packages use forks of [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go). This package aims to
-support the most popular use cases of these forks.
+Some packages use forks of [github.com/golang-jwt/jwt](https://github.com/golang-jwt/jwt). This package aims to support
+the most popular use cases of these forks.
 
 If additional forks are required for your use case, please feel free to open an issue or PR.
 
@@ -124,15 +127,15 @@ Please also see the `examples` directory.
 // Create the middleware provider.
 jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
 
-	// Use the correct version of the KeyFunc method.
-	ValidationKeyGetter: jwks.KeyFuncF3T,
+// Use the correct version of the KeyFunc method.
+ValidationKeyGetter: jwks.KeyFuncF3T,
 
-	// Always ensure that you set your signing method to avoid tokens choosing the "none" method.
-	//
-	// This shouldn't matter for this keyfunc package, as the JWKs should be trusted and determines the key type,
-	// but it's good practice.
-	// https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
-	SigningMethod: jwt.SigningMethodRS256,
+// Always ensure that you set your signing method to avoid tokens choosing the "none" method.
+//
+// This shouldn't matter for this keyfunc package, as the JWKs should be trusted and determines the key type,
+// but it's good practice.
+// https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
+SigningMethod: jwt.SigningMethodRS256,
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jwksURL := os.Getenv("JWKS_URL")
 
 // Confirm the environment variable is not empty.
 if jwksURL == "" {
-log.Fatalln("JWKS_URL environment variable must be populated.")
+	log.Fatalln("JWKS_URL environment variable must be populated.")
 }
 ```
 
@@ -76,7 +76,7 @@ Via HTTP:
 // Create the JWKs from the resource at the given URL.
 jwks, err := keyfunc.Get(jwksURL)
 if err != nil {
-log.Fatalf("Failed to get the JWKs from the given URL.\nError:%s\n", err.Error())
+	log.Fatalf("Failed to get the JWKs from the given URL.\nError:%s\n", err.Error())
 }
 ```
 Via JSON:
@@ -87,7 +87,7 @@ var jwksJSON = json.RawMessage(`{"keys":[{"kid":"zXew0UJ1h6Q4CCcd_9wxMzvcp5cEBif
 // Create the JWKs from the resource at the given URL.
 jwks, err := keyfunc.New(jwksJSON)
 if err != nil {
-log.Fatalf("Failed to create JWKs from JSON.\nError:%s\n", err.Error())
+	log.Fatalf("Failed to create JWKs from JSON.\nError:%s\n", err.Error())
 }
 ```
 
@@ -101,7 +101,7 @@ additional features mentioned at the bottom of this `README.md`.
 // Parse the JWT.
 token, err := jwt.Parse(jwtB64, jwks.KeyFunc)
 if err != nil {
-return nil, fmt.Errorf("failed to parse token: %w", err)
+	return nil, fmt.Errorf("failed to parse token: %w", err)
 }
 ```
 
@@ -127,15 +127,15 @@ Please also see the `examples` directory.
 // Create the middleware provider.
 jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
 
-// Use the correct version of the KeyFunc method.
-ValidationKeyGetter: jwks.KeyFuncF3T,
+	// Use the correct version of the KeyFunc method.
+	ValidationKeyGetter: jwks.KeyFuncF3T,
 
-// Always ensure that you set your signing method to avoid tokens choosing the "none" method.
-//
-// This shouldn't matter for this keyfunc package, as the JWKs should be trusted and determines the key type,
-// but it's good practice.
-// https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
-SigningMethod: jwt.SigningMethodRS256,
+	// Always ensure that you set your signing method to avoid tokens choosing the "none" method.
+	//
+	// This shouldn't matter for this keyfunc package, as the JWKs should be trusted and determines the key type,
+	// but it's good practice.
+	// https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
+	SigningMethod: jwt.SigningMethodRS256,
 })
 ```
 

--- a/examples/ctx/main.go
+++ b/examples/ctx/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/interval/main.go
+++ b/examples/interval/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/json/main.go
+++ b/examples/json/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/keycloak/main.go
+++ b/examples/keycloak/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/recommended_options/main.go
+++ b/examples/recommended_options/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
+	github.com/golang-jwt/jwt v3.2.1+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgrijalva/jwt-go"
+	legacy "github.com/dgrijalva/jwt-go"
 	f3t "github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt"
 )
 
 var (
@@ -57,6 +58,20 @@ func (j *JWKs) KeyFuncF3T(f3tToken *f3t.Token) (interface{}, error) {
 		Claims:    f3tToken.Claims,
 		Signature: f3tToken.Signature,
 		Valid:     f3tToken.Valid,
+	}
+	return j.KeyFunc(token)
+}
+
+// KeyFuncLegacy is a compatibility function that matches the signature of the legacy github.com/dgrijalva/jwt-go's
+// KeyFunc function.
+func (j *JWKs) KeyFuncLegacy(legacyToken *legacy.Token) (interface{}, error) {
+	token := &jwt.Token{
+		Raw:       legacyToken.Raw,
+		Method:    legacyToken.Method,
+		Header:    legacyToken.Header,
+		Claims:    legacyToken.Claims,
+		Signature: legacyToken.Signature,
+		Valid:     legacyToken.Valid,
 	}
 	return j.KeyFunc(token)
 }


### PR DESCRIPTION
As discussed in https://github.com/MicahParks/keyfunc/issues/9, the upstream JWT package has officially moved to `github.com/golang-jwt/jwt`. This project is also making that the primary supported JWT package.

If you're still using `github.com/dgrijalva/jwt-go`, then please upgrade this project by changing [`JWKs.KeyFunc`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKs.KeyFunc) to [`JWKs.KeyFuncLegacy`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKs.KeyFuncLegacy).