### PR TITLE
Remove github.com/dgrijalva/jwt-go for CVE-2020-26160.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ HTTPS to ensure the keys are from the correct trusted source.
 
 This repository has the following dependencies:
 * [github.com/golang-jwt/jwt/v4](https://github.com/golang-jwt/jwt)
-* [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go)
 * [github.com/form3tech-oss/jwt-go](https://github.com/form3tech-oss/jwt-go)
 
 `jwt.Keyfunc` signatures are imported from these, implemented, then exported as methods.
@@ -141,11 +140,15 @@ jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
 })
 ```
 
-### Support for [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go)
+### Support for [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go) (**DEPRECATED**)
 This project originally only supported [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go), but since it
 is no longer maintained, it's method was moved
 to [`JWKs.KeyfuncLegacy`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKs.KeyfuncLegacy) if you have not moved to
 [github.com/golang-jwt/jwt/v4](https://github.com/golang-jwt/jwt) yet.
+
+**NOTE**: The dependency on [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go) has since been removed to
+reduce the potential for someone to fall into the [CVE-2020-26160](https://github.com/advisories/GHSA-w73w-5m7g-f7qc) 
+security vulnerability.
 
 ## Test coverage
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/MicahParks/keyfunc
 go 1.13
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
 	github.com/golang-jwt/jwt/v4 v4.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible h1:/l4kBbb4/vGSsdtB5nUe8L7B9mImVMaBPw9L/0TBHU8=
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	jwtLegacy "github.com/dgrijalva/jwt-go"
 	jwtF3T "github.com/form3tech-oss/jwt-go"
 	"github.com/golang-jwt/jwt/v4"
 
@@ -177,13 +176,6 @@ func TestJWKs(t *testing.T) {
 					}
 				}
 
-				// Use the JWKs jwt.Keyfunc to parse the token for supported forks.
-				if _, err = jwtLegacy.Parse(tc.token, jwks.KeyfuncLegacy); err != nil {
-					if errors.Is(err, jwt.ErrInvalidKeyType) {
-						t.Errorf("Invaild key type selected for legacy.\nError: %s", err.Error())
-						t.FailNow()
-					}
-				}
 				if _, err = jwtF3T.Parse(tc.token, jwks.KeyfuncF3T); err != nil {
 					if errors.Is(err, jwt.ErrInvalidKeyType) {
 						t.Errorf("Invaild key type selected for F3T.\nError: %s", err.Error())

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	legacy "github.com/dgrijalva/jwt-go"
 	f3t "github.com/form3tech-oss/jwt-go"
 	"github.com/golang-jwt/jwt/v4"
 )
@@ -66,20 +65,6 @@ func (j *JWKs) KeyfuncF3T(f3tToken *f3t.Token) (interface{}, error) {
 		Claims:    f3tToken.Claims,
 		Signature: f3tToken.Signature,
 		Valid:     f3tToken.Valid,
-	}
-	return j.Keyfunc(token)
-}
-
-// KeyfuncLegacy is a compatibility function that matches the signature of the legacy github.com/dgrijalva/jwt-go's
-// Keyfunc function.
-func (j *JWKs) KeyfuncLegacy(legacyToken *legacy.Token) (interface{}, error) {
-	token := &jwt.Token{
-		Raw:       legacyToken.Raw,
-		Method:    legacyToken.Method,
-		Header:    legacyToken.Header,
-		Claims:    legacyToken.Claims,
-		Signature: legacyToken.Signature,
-		Valid:     legacyToken.Valid,
 	}
 	return j.Keyfunc(token)
 }


### PR DESCRIPTION
This removes the dependency on github.com/dgrijalva/jwt-go entirely in
order to prevent using it in the future. Due to the vulnerability of the
dependency in CVE-2020-26160 and the lack of active maintenance on the
library.

The GitHub overview of this CVE is available here: [CVE-2020-26160](https://github.com/advisories/GHSA-w73w-5m7g-f7qc)

This does introduce a breaking change (though no more breaking than renaming the method anyway) by removing the dependency entirely. But will resolve any security notices that users of this library may be encountering circumstantially just by using the keyfunc library.

Maybe this would warrant a `0.7.1` or `0.8.0`?

Curious what your thoughts on in general on removing this dependency @MicahParks 