### PR TITLE
Add nil JWKs validation in jwks.getKey

### DIFF
--- a/jwks.go
+++ b/jwks.go
@@ -16,6 +16,9 @@ var (
 
 	// ErrMissingAssets indicates there are required assets missing to create a public key.
 	ErrMissingAssets = errors.New("required assets are missing to create a public key")
+
+	// ErrNilJWKs indicates that an invalid JWKs (nil pointer) is being used
+	ErrNilJWKs = errors.New("the used JWKs should not be nil")
 )
 
 // ErrorHandler is a function signature that consumes an error.
@@ -100,6 +103,13 @@ func (j *JWKs) KIDs() (kids []string) {
 
 // getKey gets the jsonKey from the given KID from the JWKs. It may refresh the JWKs if configured to.
 func (j *JWKs) getKey(kid string) (jsonKey *jsonKey, err error) {
+
+	// Check if the JWKs is nil
+	if j == nil {
+		// If the pointer is pointing to nil, return the respective error
+		// in order to avoid nil pointer dereference.
+		return nil, ErrNilJWKs
+	}
 
 	// Get the jsonKey from the JWKs.
 	var ok bool


### PR DESCRIPTION
In order to prevent `panic: nil pointer dereference`, this PR adds one simple verification before using the mutex present in the JWKs structure.

Example of panic:
```
2021/10/06 08:20:00 http: panic serving 127.0.0.1:46882: runtime error: invalid memory address or nil pointer dereference
goroutine 50 [running]:
net/http.(*conn).serve.func1()
        /usr/lib/go/src/net/http/server.go:1801 +0xb9
panic({0x681340, 0x8e7ba0})
        /usr/lib/go/src/runtime/panic.go:1047 +0x266
github.com/MicahParks/keyfunc.(*JWKs).getKey(0x0, {0xc00001c390, 0x2b})
        /home/alcides/go/pkg/mod/github.com/!micah!parks/keyfunc@v0.8.3/jwks.go:106 +0x66
github.com/MicahParks/keyfunc.(*JWKs).Keyfunc(0xc0000880f0, 0xc0000880f0)
        /home/alcides/go/pkg/mod/github.com/!micah!parks/keyfunc@v0.8.3/keyfunc.go:36 +0x145
github.com/golang-jwt/jwt/v4.(*Parser).ParseWithClaims(0xc00009d930, {0xc0003a6007, 0xc0000d2038}, {0x728b80, 0xc00055c270}, 0xc00009d980)
        /home/alcides/go/pkg/mod/github.com/golang-jwt/jwt/v4@v4.1.0/parser.go:51 +0xf8
github.com/golang-jwt/jwt/v4.(*Parser).Parse(...)
        /home/alcides/go/pkg/mod/github.com/golang-jwt/jwt/v4@v4.1.0/parser.go:20
github.com/golang-jwt/jwt/v4.Parse({0xc0003a6007, 0x6d7}, 0x1)
        /home/alcides/go/pkg/mod/github.com/golang-jwt/jwt/v4@v4.1.0/token.go:89 +0x65
poc-gateway/pkg/plugins.OIDCPlugin.Process({{0x0, 0x0}, 0x0}, 0xc00055e040)
        /home/alcides/ll/src/poc-gateway/pkg/plugins/oidc.go:31 +0xd7
poc-gateway/pkg.GatewayService.ProxyDispatcher.func1({0x72e4e8, 0xc00015c000}, 0x0)
        /home/alcides/ll/src/poc-gateway/pkg/rev_proxy.go:23 +0x11c
net/http.HandlerFunc.ServeHTTP(0x4, {0x72e4e8, 0xc00015c000}, 0x7f9905861108)
        /usr/lib/go/src/net/http/server.go:2046 +0x2f
net/http.(*ServeMux).ServeHTTP(0x0, {0x72e4e8, 0xc00015c000}, 0xc00048c100)
        /usr/lib/go/src/net/http/server.go:2424 +0x149
net/http.serverHandler.ServeHTTP({0xc00055c180}, {0x72e4e8, 0xc00015c000}, 0xc00048c100)
        /usr/lib/go/src/net/http/server.go:2878 +0x43b
net/http.(*conn).serve(0xc0000aa3c0, {0x72f480, 0xc00041e4e0})
        /usr/lib/go/src/net/http/server.go:1929 +0xb08
created by net/http.(*Server).Serve
        /usr/lib/go/src/net/http/server.go:3033 +0x4e8
```