### PR TITLE
Use interface instead of implementation for http.client. 

### DIFF
--- a/get.go
+++ b/get.go
@@ -16,6 +16,10 @@ var (
 	defaultRefreshTimeout = time.Minute
 )
 
+type HttpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Get loads the JWKS at the given URL.
 func Get(jwksURL string, options Options) (jwks *JWKS, err error) {
 

--- a/jwks.go
+++ b/jwks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net/http"
 	"sync"
 	"time"
 )
@@ -36,7 +35,7 @@ type jsonWebKey struct {
 // JWKS represents a JSON Web Key Set (JWK Set).
 type JWKS struct {
 	cancel              context.CancelFunc
-	client              *http.Client
+	client             HttpClient
 	ctx                 context.Context
 	raw                 []byte
 	givenKeys           map[string]GivenKey

--- a/options.go
+++ b/options.go
@@ -2,7 +2,6 @@ package keyfunc
 
 import (
 	"context"
-	"net/http"
 	"time"
 )
 
@@ -16,7 +15,7 @@ import (
 type Options struct {
 
 	// Client is the HTTP client used to get the JWKS via HTTP.
-	Client *http.Client
+	Client HttpClient
 
 	// Ctx is the context for the keyfunc's background refresh. When the context expires or is canceled, the background
 	// goroutine will end.


### PR DESCRIPTION
In `options` there is the ability to pass in a http client. This currently has to be a `*http.Client`.

I have updated this to instead be an interface that satisfies the following:
```
type HttpClient interface {
	Do(req *http.Request) (*http.Response, error)
}
```

This makes it much easier to test code that uses this library as you can then use a mock http client that satisfies the interface.

I have run both linting and tests

Thanks!
