### PR TITLE
Support non-RFC compliant padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ jwksURL := os.Getenv("JWKS_URL")
 
 // Confirm the environment variable is not empty.
 if jwksURL == "" {
-log.Fatalln("JWKS_URL environment variable must be populated.")
+	log.Fatalln("JWKS_URL environment variable must be populated.")
 }
 ```
 
@@ -81,7 +81,7 @@ Via HTTP:
 // Create the JWKS from the resource at the given URL.
 jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{})
 if err != nil {
-log.Fatalf("Failed to get the JWKS from the given URL.\nError:%s", err.Error())
+	log.Fatalf("Failed to get the JWKS from the given URL.\nError:%s", err.Error())
 }
 ```
 Via JSON:
@@ -92,7 +92,7 @@ var jwksJSON = json.RawMessage(`{"keys":[{"kid":"zXew0UJ1h6Q4CCcd_9wxMzvcp5cEBif
 // Create the JWKS from the resource at the given URL.
 jwks, err := keyfunc.NewJSON(jwksJSON)
 if err != nil {
-log.Fatalf("Failed to create JWKS from JSON.\nError:%s", err.Error())
+	log.Fatalf("Failed to create JWKS from JSON.\nError:%s", err.Error())
 }
 ```
 Via a given key:
@@ -103,7 +103,7 @@ uniqueKeyID := "myKeyID"
 
 // Create the JWKS from the HMAC key.
 jwks := keyfunc.NewGiven(map[string]keyfunc.GivenKey{
-uniqueKeyID: keyfunc.NewGivenHMAC(key),
+	uniqueKeyID: keyfunc.NewGivenHMAC(key),
 })
 ```
 
@@ -118,7 +118,7 @@ mentioned at the bottom of this `README.md`.
 // Parse the JWT.
 token, err := jwt.Parse(jwtB64, jwks.Keyfunc)
 if err != nil {
-return nil, fmt.Errorf("failed to parse token: %w", err)
+	return nil, fmt.Errorf("failed to parse token: %w", err)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ coded JWTs cannot check for parsing and validation errors, just errors within th
   use [`jwt.RegisterSigningMethod`](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#RegisterSigningMethod) before
   parsing JWTs. For an example, see the `examples/custom` directory.
 
+## Notes
+Trailing padding is required to be removed from base64url encoded keys inside a JWKS. This is because RFC 7517 defines
+base64url the same as RFC 7515 Section 2:
+* https://datatracker.ietf.org/doc/html/rfc7517#section-1.1
+* https://datatracker.ietf.org/doc/html/rfc7515#section-2
+
+However, this package will remove trailing padding on base64url encoded keys to account for improper implementations of
+JWKS.
+
 ## References
 This project was built and tested used various RFCs and services. The services are listed below:
 * [Keycloak](https://www.keycloak.org/)

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -3,7 +3,6 @@ package keyfunc
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"encoding/base64"
 	"fmt"
 	"math/big"
 )
@@ -32,11 +31,11 @@ func (j *jsonWebKey) ECDSA() (publicKey *ecdsa.PublicKey, err error) {
 	//
 	// According to RFC 7518, this is a Base64 URL unsigned integer.
 	// https://tools.ietf.org/html/rfc7518#section-6.3
-	xCoordinate, err := base64.RawURLEncoding.DecodeString(j.X)
+	xCoordinate, err := base64urlTrailingPadding(j.X)
 	if err != nil {
 		return nil, err
 	}
-	yCoordinate, err := base64.RawURLEncoding.DecodeString(j.Y)
+	yCoordinate, err := base64urlTrailingPadding(j.Y)
 	if err != nil {
 		return nil, err
 	}

--- a/eddsa.go
+++ b/eddsa.go
@@ -2,7 +2,6 @@ package keyfunc
 
 import (
 	"crypto/ed25519"
-	"encoding/base64"
 	"fmt"
 )
 
@@ -21,7 +20,7 @@ func (j *jsonWebKey) EdDSA() (publicKey ed25519.PublicKey, err error) {
 	//
 	// According to RFC 8037, this is from Base64 URL bytes.
 	// https://datatracker.ietf.org/doc/html/rfc8037#appendix-A.2
-	publicBytes, err := base64.RawURLEncoding.DecodeString(j.X)
+	publicBytes, err := base64urlTrailingPadding(j.X)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/MicahParks/keyfunc
 
 go 1.13
 
-require github.com/golang-jwt/jwt/v4 v4.1.0
+require github.com/golang-jwt/jwt/v4 v4.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/golang-jwt/jwt/v4 v4.1.0 h1:XUgk2Ex5veyVFVeLm0xhusUTQybEbexJXrvPNOKkSY0=
-github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
+github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -1,8 +1,10 @@
 package keyfunc
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/golang-jwt/jwt/v4"
 )
@@ -25,4 +27,16 @@ func (j *JWKS) Keyfunc(token *jwt.Token) (interface{}, error) {
 	}
 
 	return j.getKey(kid)
+}
+
+// base64urlTrailingPadding removes trailing padding before decoding a string from base64url. Some non-RFC compliant
+// JWKS contain padding at the end values for base64url encoded public keys.
+//
+// Trailing padding is required to be removed from base64url encoded keys.
+// RFC 7517 defines base64url the same as RFC 7515 Section 2:
+// https://datatracker.ietf.org/doc/html/rfc7517#section-1.1
+// https://datatracker.ietf.org/doc/html/rfc7515#section-2
+func base64urlTrailingPadding(s string) ([]byte, error) {
+	s = strings.TrimRight(s, "=")
+	return base64.RawURLEncoding.DecodeString(s)
 }

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -14,8 +14,7 @@ var (
 	ErrKID = errors.New("the JWT has an invalid kid")
 )
 
-// Keyfunc is a compatibility function that matches the signature of github.com/golang-jwt/jwt/v4's jwt.Keyfunc
-// function.
+// Keyfunc matches the signature of github.com/golang-jwt/jwt/v4's jwt.Keyfunc function.
 func (j *JWKS) Keyfunc(token *jwt.Token) (interface{}, error) {
 	kidInter, ok := token.Header["kid"]
 	if !ok {

--- a/oct.go
+++ b/oct.go
@@ -1,7 +1,6 @@
 package keyfunc
 
 import (
-	"encoding/base64"
 	"fmt"
 )
 
@@ -20,7 +19,7 @@ func (j *jsonWebKey) Oct() (publicKey []byte, err error) {
 	//
 	// According to RFC 7517, this is Base64 URL bytes.
 	// https://datatracker.ietf.org/doc/html/rfc7517#section-1.1
-	publicKey, err = base64.RawURLEncoding.DecodeString(j.K)
+	publicKey, err = base64urlTrailingPadding(j.K)
 	if err != nil {
 		return nil, err
 	}

--- a/override_test.go
+++ b/override_test.go
@@ -127,13 +127,13 @@ func createSignParseValidate(t *testing.T, keys map[string]*rsa.PrivateKey, jwks
 
 	token, err := jwt.Parse(jwtB64, jwks.Keyfunc)
 	if err != nil {
-		if !shouldValidate && !errors.Is(err, rsa.ErrVerification) {
+		if !shouldValidate && errors.Is(err, rsa.ErrVerification) {
 			return
 		}
 		t.Errorf("Failed to parse the JWT.\nError: %s", err.Error())
 		t.FailNow()
-
 	}
+
 	if !shouldValidate {
 		t.Errorf("The token should not have parsed properly.")
 		t.FailNow()

--- a/padding_test.go
+++ b/padding_test.go
@@ -1,0 +1,28 @@
+package keyfunc_test
+
+import (
+	"testing"
+
+	"github.com/MicahParks/keyfunc"
+)
+
+const (
+	// jwksWithPadding has trailing = for base64url padding, which is non-RFC compliant padding, but still supported.
+	jwksWithPadding = `{"keys":[{"kty":"RSA","use":"sig","kid":"hw1T/zfqTKIT2DYbY1vweU1sLxT4SmhsgkCsHq00Ix8=","n":"0P9Deg7S0HYuM7QdDOVpXycDErBfpPqxtxKURsNCyrtlopsbW3V-kXdQSj3_QXNaaJh9hTT9l46sl6e1x713ZMcBQI1-3xjfqSPK7POu21KIQG76eSt1A4xfOU7Wj_tfhaYuu_Axwr8RcmHCxNm0umqEIMjoyd1o30xBYkpeSCiaNnqpAldyzVVFox5WAkUaQo0GFmuf9RKddprIwtDSq4DpmlPV41Qe6NUBnQ5mZnWFsJohzpnI1YacpUUfdA7ZWbnEhg5ZKlb9hl80yPKQUBjVoeMZUuB1BDOyP-HBAQgmtCrCfsm26JX2bZtagl3xdy9yQNuIK9Ly75iSXIIrFw==","e":"AQAB","alg":"RS256"}]}`
+)
+
+// TestNonRFCPadding confirms that a JWKS with keys that contain padding at the end values for base64url encoded public
+// keys. Having this trailing padding is not RFC compliant, but supported anyway.
+func TestNonRFCPadding(t *testing.T) {
+	jwks, err := keyfunc.NewJSON([]byte(jwksWithPadding))
+	if err != nil {
+		t.Errorf("Failed to parse the JWKS with padding.\nError: %s", err.Error())
+		t.FailNow()
+	}
+
+	// Confirm all the keys in the JWKS were parsed.
+	if len(jwks.KIDs()) != 1 {
+		t.Errorf("Not all keys with padding were parsed.\n  Expected: %d\n  Actual: %d", 1, len(jwks.KIDs()))
+		t.FailNow()
+	}
+}

--- a/rsa.go
+++ b/rsa.go
@@ -2,7 +2,6 @@ package keyfunc
 
 import (
 	"crypto/rsa"
-	"encoding/base64"
 	"fmt"
 	"math/big"
 )
@@ -22,11 +21,11 @@ func (j *jsonWebKey) RSA() (publicKey *rsa.PublicKey, err error) {
 	//
 	// According to RFC 7518, this is a Base64 URL unsigned integer.
 	// https://tools.ietf.org/html/rfc7518#section-6.3
-	exponent, err := base64.RawURLEncoding.DecodeString(j.Exponent)
+	exponent, err := base64urlTrailingPadding(j.Exponent)
 	if err != nil {
 		return nil, err
 	}
-	modulus, err := base64.RawURLEncoding.DecodeString(j.Modulus)
+	modulus, err := base64urlTrailingPadding(j.Modulus)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The purpose of this MR is to support non-RFC compliant padding for base64url encoded JWKS assets. Related issue: https://github.com/MicahParks/keyfunc/issues/30

Trailing padding is required to be removed from base64url encoded keys. This is because RFC 7517 defines base64url the same as RFC 7515 Section 2:
* https://datatracker.ietf.org/doc/html/rfc7517#section-1.1
* https://datatracker.ietf.org/doc/html/rfc7515#section-2
> with all trailing '=' characters omitted

However, not all JWKS are perfectly RFC compliant and some include trailing `=` characters for their base64url encoding. These non-RFC compliant JWKS implementations will be supported since it's trivial to support the removal of trailing `=` client side and will not impact performance in any noticeable way.