### PR TITLE
Request factory edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Via HTTP:
 // Create the JWKS from the resource at the given URL.
 jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{})
 if err != nil {
-	log.Fatalf("Failed to get the JWKS from the given URL.\nError:%s", err.Error())
+	log.Fatalf("Failed to get the JWKS from the given URL.\nError: %s", err)
 }
 ```
 Via JSON:
@@ -92,7 +92,7 @@ var jwksJSON = json.RawMessage(`{"keys":[{"kid":"zXew0UJ1h6Q4CCcd_9wxMzvcp5cEBif
 // Create the JWKS from the resource at the given URL.
 jwks, err := keyfunc.NewJSON(jwksJSON)
 if err != nil {
-	log.Fatalf("Failed to create JWKS from JSON.\nError:%s", err.Error())
+	log.Fatalf("Failed to create JWKS from JSON.\nError: %s", err)
 }
 ```
 Via a given key:

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ These features can be configured by populating fields in the
 	  paired with `RefreshRateLimit` to prevent abuse. For an example, please see the `examples/recommended_options`
 	  directory.
 * A custom HTTP client can be used.
+* A custom HTTP request factory can be provided to create HTTP requests for the remote JWKS resource. For example, an
+  HTTP header can be added to indicate a User-Agent.
 * A map of JWT key IDs (`kid`) to keys can be given and used for the `jwt.Keyfunc`. For an example, see
   the `examples/given` directory.
 * Custom cryptographic algorithms can be used. Make sure to

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -39,7 +39,7 @@ func TestChecksum(t *testing.T) {
 	defer server.Close()
 
 	testingRefreshErrorHandler := func(err error) {
-		panic(fmt.Sprintf("Unhandled JWKS error: %s", err.Error()))
+		panic(fmt.Sprintf(logFmt, "Unhandled JWKS error.", err))
 	}
 	opts := keyfunc.Options{
 		RefreshErrorHandler: testingRefreshErrorHandler,

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -19,14 +19,12 @@ import (
 func TestChecksum(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "*")
 	if err != nil {
-		t.Errorf("Failed to create a temporary directory.\nError: %s", err.Error())
-		t.FailNow()
+		t.Fatalf(logFmt, "Failed to create a temporary directory.", err)
 	}
 	defer func() {
 		err = os.RemoveAll(tempDir)
 		if err != nil {
-			t.Errorf("Failed to remove temporary directory.\nError: %s", err.Error())
-			t.FailNow()
+			t.Fatalf(logFmt, "Failed to remove temporary directory.", err)
 		}
 	}()
 
@@ -34,8 +32,7 @@ func TestChecksum(t *testing.T) {
 
 	err = ioutil.WriteFile(jwksFile, []byte(jwksJSON), 0600)
 	if err != nil {
-		t.Errorf("Failed to write JWKS file to temporary directory.\nError: %s", err.Error())
-		t.FailNow()
+		t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 	}
 
 	server := httptest.NewServer(http.FileServer(http.Dir(tempDir)))
@@ -53,8 +50,7 @@ func TestChecksum(t *testing.T) {
 
 	jwks, err := keyfunc.Get(jwksURL, opts)
 	if err != nil {
-		t.Errorf("Failed to get JWKS from testing URL.\nError: %s", err.Error())
-		t.FailNow()
+		t.Fatalf(logFmt, "Failed to get JWKS from testing URL.", err)
 	}
 	defer jwks.EndBackground()
 
@@ -68,8 +64,7 @@ func TestChecksum(t *testing.T) {
 	token.Header["kid"] = "unknown"
 	signed, err := token.SignedString([]byte("test"))
 	if err != nil {
-		t.Errorf("Failed to sign test JWT.\nError: %s", err.Error())
-		t.FailNow()
+		t.Fatalf(logFmt, "Failed to sign test JWT.", err)
 	}
 
 	// Force the JWKS to refresh.
@@ -78,26 +73,22 @@ func TestChecksum(t *testing.T) {
 	// Confirm the keys in the JWKS have not been refreshed.
 	newKeys := jwks.ReadOnlyKeys()
 	if len(newKeys) != len(cryptoKeyPointers) {
-		t.Errorf("The number of keys should not be different.")
-		t.FailNow()
+		t.Fatalf("The number of keys should not be different.")
 	}
 	for kid, cryptoKey := range newKeys {
 		if !reflect.DeepEqual(cryptoKeyPointers[kid], cryptoKey) {
-			t.Errorf("The JWKS should not have refreshed without a checksum change.")
-			t.FailNow()
+			t.Fatalf("The JWKS should not have refreshed without a checksum change.")
 		}
 	}
 
 	// Write a different JWKS.
 	_, _, jwksBytes, _, err := keysAndJWKS()
 	if err != nil {
-		t.Errorf("Failed to create a test JWKS.\nError: %s", err.Error())
-		t.FailNow()
+		t.Fatalf(logFmt, "Failed to create a test JWKS.", err)
 	}
 	err = ioutil.WriteFile(jwksFile, jwksBytes, 0600)
 	if err != nil {
-		t.Errorf("Failed to write JWKS file to temporary directory.\nError: %s", err.Error())
-		t.FailNow()
+		t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 	}
 
 	// Force the JWKS to refresh.
@@ -113,7 +104,6 @@ func TestChecksum(t *testing.T) {
 		}
 	}
 	if !different {
-		t.Errorf("A different JWKS checksum should have triggered a JWKS refresh.")
-		t.FailNow()
+		t.Fatalf("A different JWKS checksum should have triggered a JWKS refresh.")
 	}
 }

--- a/given_test.go
+++ b/given_test.go
@@ -50,8 +50,7 @@ func TestNewGivenKeyECDSA(t *testing.T) {
 	givenKeys := make(map[string]keyfunc.GivenKey)
 	key, err := addECDSA(givenKeys, testKID)
 	if err != nil {
-		t.Errorf(err.Error())
-		t.FailNow()
+		t.Fatalf(err.Error())
 	}
 
 	jwks := keyfunc.NewGiven(givenKeys)
@@ -67,8 +66,7 @@ func TestNewGivenKeyEdDSA(t *testing.T) {
 	givenKeys := make(map[string]keyfunc.GivenKey)
 	key, err := addEdDSA(givenKeys, testKID)
 	if err != nil {
-		t.Errorf(err.Error())
-		t.FailNow()
+		t.Fatalf(err.Error())
 	}
 
 	jwks := keyfunc.NewGiven(givenKeys)
@@ -84,8 +82,7 @@ func TestNewGivenKeyHMAC(t *testing.T) {
 	givenKeys := make(map[string]keyfunc.GivenKey)
 	key, err := addHMAC(givenKeys, testKID)
 	if err != nil {
-		t.Errorf(err.Error())
-		t.FailNow()
+		t.Fatalf(err.Error())
 	}
 
 	jwks := keyfunc.NewGiven(givenKeys)
@@ -101,8 +98,7 @@ func TestNewGivenKeyRSA(t *testing.T) {
 	givenKeys := make(map[string]keyfunc.GivenKey)
 	key, err := addRSA(givenKeys, testKID)
 	if err != nil {
-		t.Errorf(err.Error())
-		t.FailNow()
+		t.Fatalf(err.Error())
 	}
 
 	jwks := keyfunc.NewGiven(givenKeys)
@@ -173,18 +169,15 @@ func addRSA(givenKeys map[string]keyfunc.GivenKey, kid string) (key *rsa.Private
 func signParseValidate(t *testing.T, token *jwt.Token, key interface{}, jwks *keyfunc.JWKS) {
 	jwtB64, err := token.SignedString(key)
 	if err != nil {
-		t.Errorf("Failed to sign the JWT.\nError: %s", err.Error())
-		t.FailNow()
+		t.Fatalf(logFmt, "Failed to sign the JWT.", err)
 	}
 
 	parsed, err := jwt.Parse(jwtB64, jwks.Keyfunc)
 	if err != nil {
-		t.Errorf("Failed to parse the JWT.\nError: %s.", err.Error())
-		t.FailNow()
+		t.Fatalf(logFmt, "Failed to parse the JWT.", err)
 	}
 
 	if !parsed.Valid {
-		t.Errorf("The JWT was not valid.")
-		t.FailNow()
+		t.Fatalf("The JWT was not valid.")
 	}
 }

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -9,9 +9,6 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
-// logFmt is an error log formatting string.
-const logFmt = "%s\nError: %s"
-
 var (
 	// ErrKID indicates that the JWT had an invalid kid.
 	ErrKID = errors.New("the JWT has an invalid kid")

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -9,6 +9,9 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
+// logFmt is an error log formatting string.
+const logFmt = "%s\nError: %s"
+
 var (
 	// ErrKID indicates that the JWT had an invalid kid.
 	ErrKID = errors.New("the JWT has an invalid kid")

--- a/options.go
+++ b/options.go
@@ -55,7 +55,8 @@ type Options struct {
 	// sure to call the JWKS.EndBackground method to end this goroutine when it's no longer needed.
 	RefreshUnknownKID bool
 
-	// RequestFactory allows use of a custom HTTP request function
+	// RequestFactory creates HTTP requests for the remote JWKS resource located at the given url. For example, an
+	// HTTP header could be added to indicate a User-Agent.
 	RequestFactory func(ctx context.Context, url string) (*http.Request, error)
 }
 

--- a/padding_test.go
+++ b/padding_test.go
@@ -16,13 +16,11 @@ const (
 func TestNonRFCPadding(t *testing.T) {
 	jwks, err := keyfunc.NewJSON([]byte(jwksWithPadding))
 	if err != nil {
-		t.Errorf("Failed to parse the JWKS with padding.\nError: %s", err.Error())
-		t.FailNow()
+		t.Fatalf(logFmt, "Failed to parse the JWKS with padding.", err)
 	}
 
 	// Confirm all the keys in the JWKS were parsed.
 	if len(jwks.KIDs()) != 1 {
-		t.Errorf("Not all keys with padding were parsed.\n  Expected: %d\n  Actual: %d", 1, len(jwks.KIDs()))
-		t.FailNow()
+		t.Fatalf("Not all keys with padding were parsed.\n  Expected: %d\n  Actual: %d", 1, len(jwks.KIDs()))
 	}
 }


### PR DESCRIPTION
This PR contains a handful of edits for the new request factory feature.
* Moved test functionality of new request factory feature to it's own function and added an HTTP header based test.
* Update comment documentation for new request factory field on `keyfunc.Options`.
* Added note about new request factory feature in `README.md`.
* Tests updated to use `Fatalf` instead of a combination of `Errorf` and `FailNow`.
* Removed usage of `err.Error()` when using string formatting.
* Using `logFmt` string formatting constant for log statements in tests.