### PR TITLE
42 ioutil replacement

### DIFF
--- a/checksum_test.go
+++ b/checksum_test.go
@@ -2,7 +2,6 @@ package keyfunc_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,7 +16,7 @@ import (
 
 // TestChecksum confirms that the JWKS will only perform a refresh if a new JWKS is read from the remote resource.
 func TestChecksum(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "*")
+	tempDir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to create a temporary directory.", err)
 	}
@@ -30,7 +29,7 @@ func TestChecksum(t *testing.T) {
 
 	jwksFile := filepath.Join(tempDir, jwksFilePath)
 
-	err = ioutil.WriteFile(jwksFile, []byte(jwksJSON), 0600)
+	err = os.WriteFile(jwksFile, []byte(jwksJSON), 0600)
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 	}
@@ -86,7 +85,7 @@ func TestChecksum(t *testing.T) {
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to create a test JWKS.", err)
 	}
-	err = ioutil.WriteFile(jwksFile, jwksBytes, 0600)
+	err = os.WriteFile(jwksFile, jwksBytes, 0600)
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 	}

--- a/get.go
+++ b/get.go
@@ -3,7 +3,7 @@ package keyfunc
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -151,7 +151,7 @@ func (j *JWKS) refresh() (err error) {
 	//goland:noinspection GoUnhandledErrorResult
 	defer resp.Body.Close()
 
-	jwksBytes, err := ioutil.ReadAll(resp.Body)
+	jwksBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -63,7 +62,7 @@ func TestInvalidServer(t *testing.T) {
 
 // TestJWKS performs a table test on the JWKS code.
 func TestJWKS(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "*")
+	tempDir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to create a temporary directory.", err)
 	}
@@ -76,7 +75,7 @@ func TestJWKS(t *testing.T) {
 
 	jwksFile := filepath.Join(tempDir, jwksFilePath)
 
-	err = ioutil.WriteFile(jwksFile, []byte(jwksJSON), 0600)
+	err = os.WriteFile(jwksFile, []byte(jwksJSON), 0600)
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 	}
@@ -208,7 +207,7 @@ func TestJWKS_KIDs(t *testing.T) {
 
 // TestRateLimit performs a test to confirm the rate limiter works as expected.
 func TestRateLimit(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "*")
+	tempDir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to create a temporary directory.", err)
 	}
@@ -330,7 +329,7 @@ func TestRateLimit(t *testing.T) {
 
 // TestRawJWKS confirms a copy of the raw JWKS is returned from the method.
 func TestRawJWKS(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "*")
+	tempDir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to create a temporary directory.", err)
 	}
@@ -343,7 +342,7 @@ func TestRawJWKS(t *testing.T) {
 
 	jwksFile := filepath.Join(tempDir, jwksFilePath)
 
-	err = ioutil.WriteFile(jwksFile, []byte(jwksJSON), 0600)
+	err = os.WriteFile(jwksFile, []byte(jwksJSON), 0600)
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 	}
@@ -377,7 +376,7 @@ func TestRawJWKS(t *testing.T) {
 func TestRequestFactory(t *testing.T) {
 	var fullJWKSHandler http.Handler
 	{
-		tempDir, err := ioutil.TempDir("", "*")
+		tempDir, err := os.MkdirTemp("", "*")
 		if err != nil {
 			t.Fatalf(logFmt, "Failed to create a temporary directory.", err)
 		}
@@ -390,7 +389,7 @@ func TestRequestFactory(t *testing.T) {
 
 		jwksFile := filepath.Join(tempDir, jwksFilePath)
 
-		err = ioutil.WriteFile(jwksFile, []byte(jwksJSON), 0600)
+		err = os.WriteFile(jwksFile, []byte(jwksJSON), 0600)
 		if err != nil {
 			t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 		}
@@ -399,7 +398,7 @@ func TestRequestFactory(t *testing.T) {
 	}
 	var emptyJWKSHandler http.Handler
 	{
-		tempDir, err := ioutil.TempDir("", "*")
+		tempDir, err := os.MkdirTemp("", "*")
 		if err != nil {
 			t.Fatalf(logFmt, "Failed to create a temporary directory.", err)
 		}
@@ -412,7 +411,7 @@ func TestRequestFactory(t *testing.T) {
 
 		jwksFile := filepath.Join(tempDir, jwksFilePath)
 
-		err = ioutil.WriteFile(jwksFile, []byte(emptyJWKSJSON), 0600)
+		err = os.WriteFile(jwksFile, []byte(emptyJWKSJSON), 0600)
 		if err != nil {
 			t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 		}
@@ -486,7 +485,7 @@ func TestRequestFactory(t *testing.T) {
 
 // TestUnknownKIDRefresh performs a test to confirm that an Unknown kid with refresh the JWKS.
 func TestUnknownKIDRefresh(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "*")
+	tempDir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to create a temporary directory.", err)
 	}
@@ -499,7 +498,7 @@ func TestUnknownKIDRefresh(t *testing.T) {
 
 	jwksFile := filepath.Join(tempDir, strings.TrimPrefix(jwksFilePath, "/"))
 
-	err = ioutil.WriteFile(jwksFile, []byte(emptyJWKSJSON), 0600)
+	err = os.WriteFile(jwksFile, []byte(emptyJWKSJSON), 0600)
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 	}
@@ -524,7 +523,7 @@ func TestUnknownKIDRefresh(t *testing.T) {
 	}
 	defer jwks.EndBackground()
 
-	err = ioutil.WriteFile(jwksFile, []byte(jwksJSON), 0600)
+	err = os.WriteFile(jwksFile, []byte(jwksJSON), 0600)
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 	}

--- a/override_test.go
+++ b/override_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +39,7 @@ type pseudoJSONKey struct {
 
 // TestNewGiven tests that given keys will be added to a JWKS with a remote resource.
 func TestNewGiven(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "*")
+	tempDir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to create a temporary directory.", err)
 	}
@@ -58,7 +57,7 @@ func TestNewGiven(t *testing.T) {
 		t.Fatalf(logFmt, "Failed to create cryptographic keys for the test.", err)
 	}
 
-	err = ioutil.WriteFile(jwksFile, jwksBytes, 0600)
+	err = os.WriteFile(jwksFile, jwksBytes, 0600)
 	if err != nil {
 		t.Fatalf(logFmt, "Failed to write JWKS file to temporary directory.", err)
 	}


### PR DESCRIPTION
The `ioutil` package is now considered to be deprecated.  This PR replaces all found usages of the `ioutil` package with appropriate calls to the `io` or `os` package instead

Issue: https://github.com/MicahParks/keyfunc/issues/42