### PR TITLE
Bump minimum Go version to 1.16 to match the dependant package and io…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/MicahParks/keyfunc
 
-go 1.13
+go 1.16
 
 require github.com/golang-jwt/jwt/v4 v4.4.1


### PR DESCRIPTION
…/ioutil deprecation replacements