### PR TITLE
Support for `jwt` v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # keyfunc
 
 The purpose of this package is to provide a
-[`jwt.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#Keyfunc) for the
-[github.com/golang-jwt/jwt/v4](https://github.com/golang-jwt/jwt) package using a JSON Web Key Set (JWK Set or JWKS) for
+[`jwt.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#Keyfunc) for the
+[github.com/golang-jwt/jwt/v5](https://github.com/golang-jwt/jwt) package using a JSON Web Key Set (JWK Set or JWKS) for
 parsing and verifying JSON Web Tokens (JWTs).
 
 There is legacy support for `github.com/dgrijalva/jwt-go` and its popular forks. It's in a separate project to keep this
@@ -14,10 +14,10 @@ see: [github.com/MicahParks/compatibility-keyfunc](https://github.com/MicahParks
 It's common for an identity provider, such as [Keycloak](https://www.keycloak.org/)
 or [Amazon Cognito (AWS)](https://aws.amazon.com/cognito/) to expose a JWKS via an HTTPS endpoint. This package has the
 ability to consume that JWKS and produce a
-[`jwt.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#Keyfunc). It is important that a JWKS endpoint is using
+[`jwt.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#Keyfunc). It is important that a JWKS endpoint is using
 HTTPS to ensure the keys are from the correct trusted source.
 
-This repository only depends on: [github.com/golang-jwt/jwt/v4](https://github.com/golang-jwt/jwt)
+This repository only depends on: [github.com/golang-jwt/jwt/v5](https://github.com/golang-jwt/jwt)
 
 `jwt.Keyfunc` signatures are imported from these, implemented, then exported as methods.
 
@@ -57,7 +57,7 @@ import "github.com/MicahParks/keyfunc"
 
 The [`JWKS.ReadOnlyKeys`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKS.ReadOnlyKeys) method returns a read-only
 copy of a `map[string]interface{}`. The key to this map is the key ID, `kid`, and the value is the cryptographic key.
-This is a useful map for use of keys within a JWKS outside of `github.com/golang-jwt/jwt/v4`.
+This is a useful map for use of keys within a JWKS outside of `github.com/golang-jwt/jwt/v5`.
 
 The map itself is a copy. So it can be modified safely. However, the values are of type `interface{}`. If these values
 are modified, it may cause undefined behavior.
@@ -115,11 +115,11 @@ jwks := keyfunc.NewGiven(map[string]keyfunc.GivenKey{
 })
 ```
 
-Additional options can be passed to the [`keyfunc.Get`](https://pkg.go.dev/github.com/golang-jwt/jwt/v4/keyfunc#Get)
-function. See [`keyfunc.Options`](https://pkg.go.dev/github.com/golang-jwt/jwt/v4/keyfunc#Options) and the additional
+Additional options can be passed to the [`keyfunc.Get`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5/keyfunc#Get)
+function. See [`keyfunc.Options`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5/keyfunc#Options) and the additional
 features mentioned at the bottom of this `README.md`.
 
-### Step 2: Use the [`JWKS.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt/v4/keyfunc#JWKS.Keyfunc) method as the [`jwt.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#Keyfunc) when parsing tokens
+### Step 2: Use the [`JWKS.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5/keyfunc#JWKS.Keyfunc) method as the [`jwt.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#Keyfunc) when parsing tokens
 
 ```go
 // Parse the JWT.
@@ -178,7 +178,7 @@ These features can be configured by populating fields in the
   the `examples/given` directory.
 * A copy of the latest raw JWKS `[]byte` can be returned.
 * Custom cryptographic algorithms can be used. Make sure to
-  use [`jwt.RegisterSigningMethod`](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#RegisterSigningMethod) before
+  use [`jwt.RegisterSigningMethod`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#RegisterSigningMethod) before
   parsing JWTs. For an example, see the `examples/custom` directory.
 * The remote JWKS resource can be refreshed manually using the `.Refresh` method. This can bypass the rate limit, if the
   option is set.

--- a/alg_test.go
+++ b/alg_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/aws_cognito/main.go
+++ b/examples/aws_cognito/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/ctx/main.go
+++ b/examples/ctx/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 	"github.com/MicahParks/keyfunc/examples/custom/method"

--- a/examples/custom/method/method.go
+++ b/examples/custom/method/method.go
@@ -7,13 +7,13 @@ const CustomAlgHeader = "customalg"
 type EmptyCustom struct{}
 
 // Verify helps implement the jwt.SigningMethod interface. It does not verify.
-func (e EmptyCustom) Verify(_, _ string, _ interface{}) error {
+func (e EmptyCustom) Verify(_ string, _ []byte, _ interface{}) error {
 	return nil
 }
 
 // Sign helps implement the jwt.SigningMethod interface. It does not sign anything.
-func (e EmptyCustom) Sign(_ string, _ interface{}) (string, error) {
-	return CustomAlgHeader, nil
+func (e EmptyCustom) Sign(_ string, _ interface{}) ([]byte, error) {
+	return []byte{}, nil
 }
 
 // Alg helps implement the jwt.SigningMethod. It returns the `alg` JSON attribute for JWTs signed with this method.

--- a/examples/given/main.go
+++ b/examples/given/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/hmac/main.go
+++ b/examples/hmac/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/interval/main.go
+++ b/examples/interval/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/json/main.go
+++ b/examples/json/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/keycloak/main.go
+++ b/examples/keycloak/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/examples/recommended_options/main.go
+++ b/examples/recommended_options/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/given.go
+++ b/given.go
@@ -45,7 +45,7 @@ func NewGiven(givenKeys map[string]GivenKey) (jwks *JWKS) {
 // NewGivenCustom creates a new GivenKey given an untyped variable. The key argument is expected to be a supported
 // by the jwt package used.
 //
-// See the https://pkg.go.dev/github.com/golang-jwt/jwt/v4#RegisterSigningMethod function for registering an unsupported
+// See the https://pkg.go.dev/github.com/golang-jwt/jwt/v5#RegisterSigningMethod function for registering an unsupported
 // signing method.
 //
 // Deprecated: This function does not allow the user to specify the JWT's signing algorithm. Use
@@ -61,7 +61,7 @@ func NewGivenCustom(key interface{}) (givenKey GivenKey) {
 //
 // Consider the options carefully as each field may have a security implication.
 //
-// See the https://pkg.go.dev/github.com/golang-jwt/jwt/v4#RegisterSigningMethod function for registering an unsupported
+// See the https://pkg.go.dev/github.com/golang-jwt/jwt/v5#RegisterSigningMethod function for registering an unsupported
 // signing method.
 func NewGivenCustomWithOptions(key interface{}, options GivenKeyOptions) (givenKey GivenKey) {
 	return GivenKey{

--- a/given_test.go
+++ b/given_test.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 	"github.com/MicahParks/keyfunc/examples/custom/method"

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/MicahParks/keyfunc
 
 go 1.16
 
-require github.com/golang-jwt/jwt/v4 v4.4.2
+require (
+	github.com/golang-jwt/jwt/v5 v5.0.0-20220827114201-5735b9c09c4f
+)
 
 retract v1.3.0 // Contains a bug in ResponseExtractorStatusOK where the *http.Response body is not closed. https://github.com/MicahParks/keyfunc/issues/51

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/MicahParks/keyfunc
 
 go 1.16
 
-require github.com/golang-jwt/jwt/v5 v5.0.0-rc.1
+require github.com/golang-jwt/jwt/v5 v5.0.0-rc.2

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/MicahParks/keyfunc
 
 go 1.16
 
-require github.com/golang-jwt/jwt/v5 v5.0.0-rc.2
+require github.com/golang-jwt/jwt/v5 v5.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,4 @@ module github.com/MicahParks/keyfunc
 
 go 1.16
 
-require (
-	github.com/golang-jwt/jwt/v5 v5.0.0-20220827114201-5735b9c09c4f
-)
-
-retract v1.3.0 // Contains a bug in ResponseExtractorStatusOK where the *http.Response body is not closed. https://github.com/MicahParks/keyfunc/issues/51
+require github.com/golang-jwt/jwt/v5 v5.0.0-rc.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
-github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
-github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v5 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.0.0-20220827114201-5735b9c09c4f h1:vFMwvx6qRGuY4j1aZNlxMZPjF7l0Pj7L6HIDMtu6M+g=
+github.com/golang-jwt/jwt/v5 v5.0.0-20220827114201-5735b9c09c4f/go.mod h1:LStXn4ehBjSFV0xtOEuMWrqlMT24Ftd1MaucI6XwEFo=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/golang-jwt/jwt/v5 v5.0.0-rc.1 h1:tDQ1LjKga657layZ4JLsRdxgvupebc0xuPwRNuTfUgs=
-github.com/golang-jwt/jwt/v5 v5.0.0-rc.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.0.0-rc.2 h1:hXPcSazn8wKOfSb9y2m1bdgUMlDxVDarxh3lJVbC6JE=
+github.com/golang-jwt/jwt/v5 v5.0.0-rc.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/golang-jwt/jwt/v5 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
-github.com/golang-jwt/jwt/v5 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/golang-jwt/jwt/v5 v5.0.0-20220827114201-5735b9c09c4f h1:vFMwvx6qRGuY4j1aZNlxMZPjF7l0Pj7L6HIDMtu6M+g=
-github.com/golang-jwt/jwt/v5 v5.0.0-20220827114201-5735b9c09c4f/go.mod h1:LStXn4ehBjSFV0xtOEuMWrqlMT24Ftd1MaucI6XwEFo=
+github.com/golang-jwt/jwt/v5 v5.0.0-rc.1 h1:tDQ1LjKga657layZ4JLsRdxgvupebc0xuPwRNuTfUgs=
+github.com/golang-jwt/jwt/v5 v5.0.0-rc.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/golang-jwt/jwt/v5 v5.0.0-rc.2 h1:hXPcSazn8wKOfSb9y2m1bdgUMlDxVDarxh3lJVbC6JE=
-github.com/golang-jwt/jwt/v5 v5.0.0-rc.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 var (
@@ -14,7 +14,7 @@ var (
 	ErrKID = errors.New("the JWT has an invalid kid")
 )
 
-// Keyfunc matches the signature of github.com/golang-jwt/jwt/v4's jwt.Keyfunc function.
+// Keyfunc matches the signature of github.com/golang-jwt/jwt/v5's jwt.Keyfunc function.
 func (j *JWKS) Keyfunc(token *jwt.Token) (interface{}, error) {
 	kid, alg, err := kidAlg(token)
 	if err != nil {

--- a/multiple.go
+++ b/multiple.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // ErrMultipleJWKSSize is returned when the number of JWKS given are not enough to make a MultipleJWKS.

--- a/multiple_test.go
+++ b/multiple_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )

--- a/options.go
+++ b/options.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // ErrInvalidHTTPStatusCode indicates that the HTTP status code is invalid.

--- a/override_test.go
+++ b/override_test.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/MicahParks/keyfunc"
 )


### PR DESCRIPTION
This serves as an experimental draft PR for the upcoming `v5` version of `jwt`. Since we are most likely changing the `Claims` interface, this also has an effect on this library.

Basically there are two options here:
* Upgrading to the `v5` claims at some point, possibly also with another major version
* Supporting both `v4` and `v5` for example using two different functions.

Any thought on this? I am happy to make the transition as smooth as possible from the `jwt` side of things, but I fear that we do need to make this break in v4->v5, otherwise we will never succeed with a proper validation API.