### PR TITLE
Add response extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ if jwksURL == "" {
 Via HTTP:
 ```go
 // Create the JWKS from the resource at the given URL.
-jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{})
+jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{}) // See recommended options in the examples directory.
 if err != nil {
 	log.Fatalf("Failed to get the JWKS from the given URL.\nError: %s", err)
 }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ jwksURL := os.Getenv("JWKS_URL")
 
 // Confirm the environment variable is not empty.
 if jwksURL == "" {
-	log.Fatalln("JWKS_URL environment variable must be populated.")
+log.Fatalln("JWKS_URL environment variable must be populated.")
 }
 ```
 
@@ -81,7 +81,7 @@ Via HTTP:
 // Create the JWKS from the resource at the given URL.
 jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{}) // See recommended options in the examples directory.
 if err != nil {
-	log.Fatalf("Failed to get the JWKS from the given URL.\nError: %s", err)
+log.Fatalf("Failed to get the JWKS from the given URL.\nError: %s", err)
 }
 ```
 Via JSON:
@@ -92,7 +92,7 @@ var jwksJSON = json.RawMessage(`{"keys":[{"kid":"zXew0UJ1h6Q4CCcd_9wxMzvcp5cEBif
 // Create the JWKS from the resource at the given URL.
 jwks, err := keyfunc.NewJSON(jwksJSON)
 if err != nil {
-	log.Fatalf("Failed to create JWKS from JSON.\nError: %s", err)
+log.Fatalf("Failed to create JWKS from JSON.\nError: %s", err)
 }
 ```
 Via a given key:
@@ -103,7 +103,7 @@ uniqueKeyID := "myKeyID"
 
 // Create the JWKS from the HMAC key.
 jwks := keyfunc.NewGiven(map[string]keyfunc.GivenKey{
-	uniqueKeyID: keyfunc.NewGivenHMAC(key),
+uniqueKeyID: keyfunc.NewGivenHMAC(key),
 })
 ```
 
@@ -117,7 +117,7 @@ features mentioned at the bottom of this `README.md`.
 // Parse the JWT.
 token, err := jwt.Parse(jwtB64, jwks.Keyfunc)
 if err != nil {
-	return nil, fmt.Errorf("failed to parse token: %w", err)
+return nil, fmt.Errorf("failed to parse token: %w", err)
 }
 ```
 
@@ -151,6 +151,9 @@ These features can be configured by populating fields in the
 * A custom HTTP client can be used.
 * A custom HTTP request factory can be provided to create HTTP requests for the remote JWKS resource. For example, an
   HTTP header can be added to indicate a User-Agent.
+* A custom HTTP response extractor can be provided to get the raw JWKS JSON from the `*http.Response`. For example, the
+  HTTP response code could be checked. Implementations are responsible for closing the response body. By default, the
+  response body is read and closed, the status code is ignored.
 * A map of JWT key IDs (`kid`) to keys can be given and used for the `jwt.Keyfunc`. For an example, see
   the `examples/given` directory.
 * A copy of the latest raw JWKS `[]byte` can be returned.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ These features can be configured by populating fields in the
   HTTP header can be added to indicate a User-Agent.
 * A custom HTTP response extractor can be provided to get the raw JWKS JSON from the `*http.Response`. For example, the
   HTTP response code could be checked. Implementations are responsible for closing the response body. By default, the
-  response body is read and closed, the status code is ignored.
+  response body is read and closed, the status code is ignored. The default behavior is likely to be changed soon.
+  See https://github.com/MicahParks/keyfunc/issues/48.
 * A map of JWT key IDs (`kid`) to keys can be given and used for the `jwt.Keyfunc`. For an example, see
   the `examples/given` directory.
 * A copy of the latest raw JWKS `[]byte` can be returned.

--- a/examples/aws_cognito/main.go
+++ b/examples/aws_cognito/main.go
@@ -30,6 +30,7 @@ func main() {
 		RefreshRateLimit:  time.Minute * 5,
 		RefreshTimeout:    time.Second * 10,
 		RefreshUnknownKID: true,
+		ResponseExtractor: keyfunc.ResponseExtractorStatusOK,
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/examples/ctx/main.go
+++ b/examples/ctx/main.go
@@ -22,6 +22,7 @@ func main() {
 		RefreshErrorHandler: func(err error) {
 			log.Printf("There was an error with the jwt.Keyfunc\nError: %s", err.Error())
 		},
+		ResponseExtractor: keyfunc.ResponseExtractorStatusOK,
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/examples/given/main.go
+++ b/examples/given/main.go
@@ -45,6 +45,7 @@ func main() {
 		RefreshRateLimit:  time.Minute * 5,
 		RefreshTimeout:    time.Second * 10,
 		RefreshUnknownKID: true,
+		ResponseExtractor: keyfunc.ResponseExtractorStatusOK,
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/examples/interval/main.go
+++ b/examples/interval/main.go
@@ -23,6 +23,7 @@ func main() {
 		RefreshErrorHandler: func(err error) {
 			log.Printf("There was an error with the jwt.Keyfunc\nError: %s", err.Error())
 		},
+		ResponseExtractor: keyfunc.ResponseExtractorStatusOK,
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/examples/keycloak/main.go
+++ b/examples/keycloak/main.go
@@ -26,6 +26,7 @@ func main() {
 		RefreshRateLimit:  time.Minute * 5,
 		RefreshTimeout:    time.Second * 10,
 		RefreshUnknownKID: true,
+		ResponseExtractor: keyfunc.ResponseExtractorStatusOK,
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/examples/recommended_options/main.go
+++ b/examples/recommended_options/main.go
@@ -31,6 +31,7 @@ func main() {
 		RefreshRateLimit:  time.Minute * 5,
 		RefreshTimeout:    time.Second * 10,
 		RefreshUnknownKID: true,
+		ResponseExtractor: keyfunc.ResponseExtractorStatusOK,
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/get.go
+++ b/get.go
@@ -33,6 +33,9 @@ func Get(jwksURL string, options Options) (jwks *JWKS, err error) {
 	}
 	if jwks.responseExtractor == nil {
 		jwks.responseExtractor = func(ctx context.Context, resp *http.Response) (json.RawMessage, error) {
+			// This behavior is likely going to change in favor of checking the response code.
+			// See https://github.com/MicahParks/keyfunc/issues/48
+
 			//goland:noinspection GoUnhandledErrorResult
 			defer resp.Body.Close()
 			return io.ReadAll(resp.Body)

--- a/jwks.go
+++ b/jwks.go
@@ -50,6 +50,7 @@ type JWKS struct {
 	refreshTimeout      time.Duration
 	refreshUnknownKID   bool
 	requestFactory      func(ctx context.Context, url string) (*http.Request, error)
+	responseExtractor   func(ctx context.Context, resp *http.Response) (json.RawMessage, error)
 }
 
 // rawJWKS represents a JWKS in JSON format.

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -358,7 +358,7 @@ func TestRawJWKS(t *testing.T) {
 	}
 
 	raw := jwks.RawJWKS()
-	if bytes.Compare(raw, []byte(jwksJSON)) != 0 {
+	if !bytes.Equal(raw, []byte(jwksJSON)) {
 		t.Fatalf("Raw JWKS does not match remote JWKS resource.")
 	}
 
@@ -367,7 +367,7 @@ func TestRawJWKS(t *testing.T) {
 	copy(raw, emptySlice)
 
 	nextRaw := jwks.RawJWKS()
-	if bytes.Compare(nextRaw, emptySlice) == 0 {
+	if bytes.Equal(nextRaw, emptySlice) {
 		t.Fatalf("Raw JWKS is not a copy.")
 	}
 }

--- a/options.go
+++ b/options.go
@@ -68,7 +68,9 @@ type Options struct {
 
 	// ResponseExtractor consumes a *http.Response and produces the raw JSON for the JWKS. By default, the raw JSON is
 	// expected in the response body and the response's status code is not checked.
-	// See this relevant GitHub issue: https://github.com/MicahParks/keyfunc/issues/48
+	//
+	// The default behavior is likely to change soon. See this relevant GitHub issue:
+	// https://github.com/MicahParks/keyfunc/issues/48
 	ResponseExtractor func(ctx context.Context, resp *http.Response) (json.RawMessage, error)
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,45 @@
+package keyfunc_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/MicahParks/keyfunc"
+)
+
+func TestResponseExtractorStatusOK(t *testing.T) {
+	var mux sync.Mutex
+	statusCode := http.StatusOK
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		mux.Lock()
+		writer.WriteHeader(statusCode)
+		mux.Unlock()
+		_, _ = writer.Write([]byte(jwksJSON))
+	}))
+	defer server.Close()
+
+	options := keyfunc.Options{
+		ResponseExtractor: keyfunc.ResponseExtractorStatusOK,
+	}
+	jwks, err := keyfunc.Get(server.URL, options)
+	if err != nil {
+		t.Fatalf("Failed to get JWK Set from server.\nError: %s", err)
+	}
+
+	if len(jwks.ReadOnlyKeys()) == 0 {
+		t.Fatalf("Expected JWK Set to have keys.")
+	}
+
+	mux.Lock()
+	statusCode = http.StatusInternalServerError
+	mux.Unlock()
+
+	_, err = keyfunc.Get(server.URL, options)
+	if !errors.Is(err, keyfunc.ErrInvalidHTTPStatusCode) {
+		t.Fatalf("Expected error to be ErrInvalidHTTPStatusCode.\nError: %s", err)
+	}
+}


### PR DESCRIPTION
The purpose of this PR is add support for custom response extractors and provide a default, recommended, extractor that confirms the HTTP response code is `http.StatusOK`.

See these relevant issues:
* https://github.com/MicahParks/keyfunc/issues/48
* https://github.com/MicahParks/keyfunc/issues/49