### PR TITLE
Add updates to JWK "use" parameter filter before release

### DIFF
--- a/example_jwks.json
+++ b/example_jwks.json
@@ -120,17 +120,11 @@
       "k": "V_8Ob8dVs6JuZx6expyjShoUgFgxoaovGjmGhesL2jA"
     },
     {
-      "kty": "RSA",
-      "use": "enc",
-      "kid": "WW91IGdldCBhIGdvbGQgc3RhciDwn4yfCg",
-      "alg": "RSA-OAEP",
-      "n": "ja99ybDrLvw11Z4CvNlDI-kkqJEBpSnvDf0pZF2DvBlvYmeVYL_ChqIe8E9GyHUmLMdtO_jifSgOqE5b8vILwi1kZnJR7N857uEnbWM9YTeevi_RZ-E_hr4frW2NKJ78YGvCzwLKG2GgtSjj0zuTLnSaK8fCGzqXgy6paXNhgHUSZgGwvO0YItpMlyJeqEj1wGTWz1IyA1sguF1cC7K0fojPbPoBwrhvaAeoGRPLraE0rrBsQv8iiLwnRBIez9B1j0NiUG8Iad953Y7UzaKOAw8crIEK45NIK_yxHUpxqcHLjPIcRyIyJGioRyGK7cp-_7iPLOCutQc-u46mom1_ZQ",
       "e": "AQAB",
-      "x5c": [
-        "MIICmzCCAYMCBgF4BJRpbzANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZtYXN0ZXIwHhcNMjEwMzA1MjI0NzE4WhcNMzEwMzA1MjI0ODU4WjARMQ8wDQYDVQQDDAZtYXN0ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCNr33JsOsu/DXVngK82UMj6SSokQGlKe8N/SlkXYO8GW9iZ5Vgv8KGoh7wT0bIdSYsx207+OJ9KA6oTlvy8gvCLWRmclHs3znu4SdtYz1hN56+L9Fn4T+Gvh+tbY0onvxga8LPAsobYaC1KOPTO5MudJorx8IbOpeDLqlpc2GAdRJmAbC87Rgi2kyXIl6oSPXAZNbPUjIDWyC4XVwLsrR+iM9s+gHCuG9oB6gZE8utoTSusGxC/yKIvCdEEh7P0HWPQ2JQbwhp33ndjtTNoo4DDxysgQrjk0gr/LEdSnGpwcuM8hxHIjIkaKhHIYrtyn7/uI8s4K61Bz67jqaibX9lAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHrGJFhVNiQupIwkn2jiW/jBobm9CHUxOwQL5E7WdRz5uaOJ0v62PrynOQE9xim9Qk8bT3q7DThZs66U9bpIk3msKVRgXRfn5FZy1H5RKOlEEFZhGakPqSlC1yPbhUNhHXMs3GTzdGMLtYaGvSy6XM/8/zqVqVwgh6BpbAR9RfiSdyaiNTSBriu+n/tHW934G9J8UIzdfpVcb0Yt9y4o0UgIXt64NtGFq7zmNJijH88AxBZFB6eUUmQQCczebzoAjyYbVOes5gGFzboVWcyLe3iyD0vvsAVHJViXeiGoxhpKnc8ryISpRUBzsKngf5uZo3bnrD9PHLYBoGOHgzII1xw="
-      ],
-      "x5t": "5GNr3LeRXHWI4YR8-QTSsF98oTI",
-      "x5t#S256": "Dgd0_wZZqvRuf4GEISPNHREX-1ixTMIsrPeGzk0bCxs"
+      "use": "enc",
+      "kid": "kidWithBadUse",
+      "kty": "RSA",
+      "n": "znO8fsURSvghcjbMu2nysqZhsreTkj-y46YL39kctmlj7-qqVLuvTUtw0XvsxwLi9WWczz_BsAm2Rn6LzyhvXUXjj6uMP8tk-HhWc4RMXP-esqB7y6WUmR8SioT94SykuVhWMDxwkg7kXTg_GWEYibEFJ7YM16vVZ2Na5z2vRfMRy7VARXRhDrinJmW0B-oY9FurPTyaZSDqOr-3Qkhk1jm9-6ygFsOkmnd4Ljnq28t8hq_4k3bdZSolZv11boQS8vDO-Fo_2YoQVxm4YMIjcr8bxZcali2slOEytEC5ItOKTPA_CydM62sJubw7MuTrOKh6GJrq0xnw6MtqR46-MQ"
     }
   ]
 }

--- a/get.go
+++ b/get.go
@@ -35,8 +35,11 @@ func Get(jwksURL string, options Options) (jwks *JWKS, err error) {
 	if jwks.refreshTimeout == 0 {
 		jwks.refreshTimeout = defaultRefreshTimeout
 	}
-	if len(jwks.allowedJWKUses) == 0 {
-		jwks.allowedJWKUses = []JWKUse{UseSignature, UseOmitted}
+	if !options.JWKUseNoWhitelist && len(jwks.jwkUseWhitelist) == 0 {
+		jwks.jwkUseWhitelist = map[JWKUse]struct{}{
+			UseOmitted:   {},
+			UseSignature: {},
+		}
 	}
 
 	err = jwks.refresh()
@@ -184,7 +187,7 @@ func (j *JWKS) refresh() (err error) {
 				}
 			}
 
-			j.keys[kid] = parsedKey{public: key.inter}
+			j.keys[kid] = parsedJWK{public: key.inter}
 		}
 	}
 

--- a/given.go
+++ b/given.go
@@ -13,10 +13,10 @@ type GivenKey struct {
 
 // NewGiven creates a JWKS from a map of given keys.
 func NewGiven(givenKeys map[string]GivenKey) (jwks *JWKS) {
-	keys := make(map[string]parsedKey)
+	keys := make(map[string]parsedJWK)
 
 	for kid, given := range givenKeys {
-		keys[kid] = parsedKey{public: given.inter}
+		keys[kid] = parsedJWK{public: given.inter}
 	}
 
 	return &JWKS{


### PR DESCRIPTION
1. Update comments.
2. Rename `AllowedJWKUses` to `JWKUseWhitelist`.
3. Add a new field to `keyfunc.Options`. A `bool`, `JWKUseNoWhitelist`, which will override the default behavior and the `JWKUseWhitelist` field to allow any value for a JWK `use` parameter.
4. Rename a local variable, `parsedKey`, so it does not shadow a type's name.
5. Rename `ErrJWKUse` to `ErrJWKUseWhitelist`.
6. Rename `parsedKey` to `parsedJWK`.
7. Update `TestReadOnlyKeys` for preference.
8. Remove usages of `http.NewServerMux()` in tests.