### PR TITLE
Handle unknown curves

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -48,6 +48,8 @@ func (j *jsonWebKey) ECDSA() (publicKey *ecdsa.PublicKey, err error) {
 		publicKey.Curve = elliptic.P384()
 	case p521:
 		publicKey.Curve = elliptic.P521()
+	default:
+		return nil, fmt.Errorf("unknown curve: %s", j.Curve)
 	}
 
 	// Turn the X coordinate into *big.Int.

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -1,0 +1,30 @@
+package keyfunc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+func TestBadCurve(t *testing.T) {
+	const (
+		badJWKS = `{"keys":[{"kty":"EC","crv":"BAD","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","use":"sig","kid":"1"}]}`
+		someJWT = `eyJhbGciOiJFUzI1NiIsImtpZCI6IjEiLCJ0eXAiOiJKV1QifQ.e30.Q1EeyWUv6XEA0gMLwTFoNhx7Hq1MbVwjI2k9FZPSa-myKW1wYn1X6rHtRyuV-2MEzvimCskFD-afL7UzvdWBQg`
+	)
+
+	jwks, err := NewJSON(json.RawMessage(badJWKS))
+	if err != nil {
+		t.Fatalf("Failed to create JWKS from JSON: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panic")
+		}
+	}()
+
+	if _, err = jwt.Parse(someJWT, jwks.Keyfunc); err == nil {
+		t.Fatal("No error for bad curve")
+	}
+}


### PR DESCRIPTION
Attempting to verify JWTs using a JWKS with a key that has an invalid curve results in a panic (nil pointer dereference). This could result in a DoS if untrusted JWKS URLs were used. That scenario is presumably unlikely though. This PR adds a failing test and a `default` case to the key parsing logic.