### PR TITLE
Update jwkset dep for thumbprint bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.21.5
 
 require github.com/golang-jwt/jwt/v5 v5.2.0
 
-require github.com/MicahParks/jwkset v0.5.4
+require github.com/MicahParks/jwkset v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/MicahParks/jwkset v0.5.4 h1:59s9OUNIKF3g+IXYm3pa4vPXXEudRNetyy3+H6KpKdw=
-github.com/MicahParks/jwkset v0.5.4/go.mod h1:fOx7dCX+XgPDzcRbZzi9DMY3vyebWXmsz7XPqstr3ms=
+github.com/MicahParks/jwkset v0.5.5 h1:1Pob9XuVJXoiRJn8kYtpwiYfi0hE35H5YpTq4UZLrPA=
+github.com/MicahParks/jwkset v0.5.5/go.mod h1:fOx7dCX+XgPDzcRbZzi9DMY3vyebWXmsz7XPqstr3ms=
 github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
 github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=


### PR DESCRIPTION
The purpose of this pull request is to update the `github.com/MicahParks/jwkset` dependency for the thumbprint bug.

This bug occurs when a JWK Set has `x5c`, but  `x5t` and `x5t#S256` are not both present.

For more details, see:
https://github.com/MicahParks/jwkset/releases/tag/v0.5.5