### PR TITLE
Update jwkset for unknown key ID refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ JWK Set via an HTTPS endpoint. This package has the ability to consume that JWK 
 [`jwt.Keyfunc`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#Keyfunc). It is important that a JWK Set endpoint is
 using HTTPS to ensure the keys are from the correct trusted source.
 
-This repository only depends on:
-
-* [github.com/golang-jwt/jwt/v5](https://github.com/golang-jwt/jwt)
-* [github.com/MicahParks/jwkset](https://github.com/MicahParks/jwkset)
-
 ## Basic usage
 
 For complete examples, please see the `examples` directory.
@@ -73,6 +68,7 @@ the `.Storage()` method. Using the [github.com/MicahParks/jwkset](https://github
 provides the below features, and more:
 
 * An HTTP client that automatically updates one or more remote JWK Set resources.
+* An automatic refresh of remote HTTP resources when an unknown key ID (`kid`) is encountered.
 * X.509 URIs or embedded [certificate chains](https://pkg.go.dev/crypto/x509#Certificate), when a JWK contains them.
 * Support for private asymmetric keys.
 * Specified key operations and usage.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/MicahParks/keyfunc/v3
 
 go 1.21.5
 
-require github.com/golang-jwt/jwt/v5 v5.2.0
+require (
+	github.com/MicahParks/jwkset v0.5.6
+	github.com/golang-jwt/jwt/v5 v5.2.0
+)
 
-require github.com/MicahParks/jwkset v0.5.5
+require golang.org/x/time v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-github.com/MicahParks/jwkset v0.5.5 h1:1Pob9XuVJXoiRJn8kYtpwiYfi0hE35H5YpTq4UZLrPA=
-github.com/MicahParks/jwkset v0.5.5/go.mod h1:fOx7dCX+XgPDzcRbZzi9DMY3vyebWXmsz7XPqstr3ms=
+github.com/MicahParks/jwkset v0.5.6 h1:j7DxnWgzNigqpPsplDug1MR2zCzUmi8wdyHhhq/wIk4=
+github.com/MicahParks/jwkset v0.5.6/go.mod h1:6QApSQehWQGJUc1mPbUQ65YByW8IE2eXZeqFImpg4JA=
 github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
 github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
+golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=


### PR DESCRIPTION
The purpose of this pull request is to update the `jwkset` dependency so that the refresh on unknown key ID feature is available by default. 

See:
https://github.com/MicahParks/jwkset/releases/tag/v0.5.6