### PR TITLE
Add context to default functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ if err != nil {
 ```
 
 When using the `keyfunc.NewDefault` function, the JWK Set will be automatically refreshed using
-[`jwkset.NewDefaultHTTPClient`](https://pkg.go.dev/github.com/MicahParks/jwkset#NewHTTPClient).
+[`jwkset.NewDefaultHTTPClient`](https://pkg.go.dev/github.com/MicahParks/jwkset#NewHTTPClient). This does launch a "
+refresh goroutine". If you want the ability to end this goroutine, use the `keyfunc.NewDefaultHTTPClientCtx` function.
 
 It is also possible to create a `keyfunc.Keyfunc` from given keys like HMAC shared secrets. See `examples/hmac/main.go`.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MicahParks/keyfunc/v3
 go 1.21
 
 require (
-	github.com/MicahParks/jwkset v0.5.7
+	github.com/MicahParks/jwkset v0.5.12
 	github.com/golang-jwt/jwt/v5 v5.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/MicahParks/jwkset v0.5.7 h1:eHUGJrSO8EetbNnSb7xhlYQ9mX0vQ7Ga9wN1HhGL3i4=
-github.com/MicahParks/jwkset v0.5.7/go.mod h1:q8ptTGn/Z9c4MwbcfeCDssADeVQb3Pk7PnVxrvi+2QY=
+github.com/MicahParks/jwkset v0.5.12 h1:wEwKZXB77yHFIHBtYoawNKIUwqC1X24S8tIhWutJHMA=
+github.com/MicahParks/jwkset v0.5.12/go.mod h1:q8ptTGn/Z9c4MwbcfeCDssADeVQb3Pk7PnVxrvi+2QY=
 github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
 github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -55,9 +55,17 @@ func New(options Options) (Keyfunc, error) {
 
 // NewDefault creates a new Keyfunc with a default JWK Set storage and options.
 //
-// This will launch "refresh goroutines" to automatically refresh the remote HTTP resources.
+// This will launch "refresh goroutine" to automatically refresh the remote HTTP resources.
 func NewDefault(urls []string) (Keyfunc, error) {
-	client, err := jwkset.NewDefaultHTTPClient(urls)
+	return NewDefaultCtx(context.Background(), urls)
+}
+
+// NewDefaultCtx creates a new Keyfunc with a default JWK Set storage and options. The context is used to end the
+// "refresh goroutine".
+//
+// This will launch "refresh goroutine" to automatically refresh the remote HTTP resources.
+func NewDefaultCtx(ctx context.Context, urls []string) (Keyfunc, error) {
+	client, err := jwkset.NewDefaultHTTPClientCtx(ctx, urls)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The purpose of this pull request is to add a function to create a default `keyfunc.Keyfunc` that accepts a `context.Context` that can end the "refresh goroutine". 