### PR TITLE
Update jwkset for thumbprint check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MicahParks/keyfunc/v3
 go 1.21
 
 require (
-	github.com/MicahParks/jwkset v0.5.18
+	github.com/MicahParks/jwkset v0.5.19
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	golang.org/x/time v0.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/MicahParks/jwkset v0.5.18 h1:WLdyMngF7rCrnstQxA7mpRoxeaWqGzPM/0z40PJUK4w=
-github.com/MicahParks/jwkset v0.5.18/go.mod h1:q8ptTGn/Z9c4MwbcfeCDssADeVQb3Pk7PnVxrvi+2QY=
+github.com/MicahParks/jwkset v0.5.19 h1:XZCsgJv05DBCvxEHYEHlSafqiuVn5ESG0VRB331Fxhw=
+github.com/MicahParks/jwkset v0.5.19/go.mod h1:q8ptTGn/Z9c4MwbcfeCDssADeVQb3Pk7PnVxrvi+2QY=
 github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
 github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=


### PR DESCRIPTION
The purpose of this pull request is to fix a JWK thumbprint comparison bug that caused a failure when a certificate thumbprint was provided without a certificate with `x5c`.

Relevant issue:
* https://github.com/MicahParks/keyfunc/issues/128

PR form jwkset project:
* https://github.com/MicahParks/jwkset/pull/37