### PR TITLE
Return all keys when JWT has no key ID header

### DIFF
--- a/keyfunc.go
+++ b/keyfunc.go
@@ -25,6 +25,7 @@ type Keyfunc interface {
 	Keyfunc(token *jwt.Token) (any, error)
 	KeyfuncCtx(ctx context.Context) jwt.Keyfunc
 	Storage() jwkset.Storage
+	VerificationKeySet(ctx context.Context) (jwt.VerificationKeySet, error)
 }
 
 // Options are used to create a new Keyfunc.

--- a/keyfunc_test.go
+++ b/keyfunc_test.go
@@ -204,7 +204,7 @@ func TestVerificationKeySet(t *testing.T) {
 	}
 }
 
-func TestKeyfuncCtx_NoKIDHeader_CallsVerificationKeySet(t *testing.T) {
+func TestNoKIDHeaderCallsVerificationKeySet(t *testing.T) {
 	ctx := context.Background()
 
 	// Generate two key pairs.


### PR DESCRIPTION
The purpose of this pull request is to utilize the [`jwt.VerificationKeySet`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#VerificationKeySet) feature to allow use cases without key IDs to use this project.

Closes #138 